### PR TITLE
[Min, Aiden] Step-2 Photos 라이브러리 활용하여 사진 불러오기

### DIFF
--- a/PhotosApp/PhotosApp.xcodeproj/project.pbxproj
+++ b/PhotosApp/PhotosApp.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		BD40D1922609B5A200A02F46 /* CollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD40D1902609B5A200A02F46 /* CollectionViewCell.swift */; };
 		BD40D1932609B5A200A02F46 /* CollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = BD40D1912609B5A200A02F46 /* CollectionViewCell.xib */; };
+		BD40D198260ACD1C00A02F46 /* ExtentionUIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD40D197260ACD1C00A02F46 /* ExtentionUIColor.swift */; };
 		D4258B6C26086153006EDA08 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4258B6B26086153006EDA08 /* AppDelegate.swift */; };
 		D4258B6E26086153006EDA08 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4258B6D26086153006EDA08 /* SceneDelegate.swift */; };
 		D4258B7026086153006EDA08 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4258B6F26086153006EDA08 /* ViewController.swift */; };
@@ -39,6 +40,7 @@
 /* Begin PBXFileReference section */
 		BD40D1902609B5A200A02F46 /* CollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewCell.swift; sourceTree = "<group>"; };
 		BD40D1912609B5A200A02F46 /* CollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CollectionViewCell.xib; sourceTree = "<group>"; };
+		BD40D197260ACD1C00A02F46 /* ExtentionUIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtentionUIColor.swift; sourceTree = "<group>"; };
 		D4258B6826086153006EDA08 /* PhotosApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PhotosApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4258B6B26086153006EDA08 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D4258B6D26086153006EDA08 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -107,6 +109,7 @@
 				D4258B6D26086153006EDA08 /* SceneDelegate.swift */,
 				D4258B6F26086153006EDA08 /* ViewController.swift */,
 				BD40D1902609B5A200A02F46 /* CollectionViewCell.swift */,
+				BD40D197260ACD1C00A02F46 /* ExtentionUIColor.swift */,
 				BD40D1912609B5A200A02F46 /* CollectionViewCell.xib */,
 				D4258B7126086153006EDA08 /* Main.storyboard */,
 				D4258B7426086155006EDA08 /* Assets.xcassets */,
@@ -266,6 +269,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D4258B7026086153006EDA08 /* ViewController.swift in Sources */,
+				BD40D198260ACD1C00A02F46 /* ExtentionUIColor.swift in Sources */,
 				D4258B6C26086153006EDA08 /* AppDelegate.swift in Sources */,
 				BD40D1922609B5A200A02F46 /* CollectionViewCell.swift in Sources */,
 				D4258B6E26086153006EDA08 /* SceneDelegate.swift in Sources */,

--- a/PhotosApp/PhotosApp.xcodeproj/project.pbxproj
+++ b/PhotosApp/PhotosApp.xcodeproj/project.pbxproj
@@ -7,7 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		BD40D1812609885300A02F46 /* CollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD40D1802609885300A02F46 /* CollectionViewCell.swift */; };
+		BD40D1922609B5A200A02F46 /* CollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD40D1902609B5A200A02F46 /* CollectionViewCell.swift */; };
+		BD40D1932609B5A200A02F46 /* CollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = BD40D1912609B5A200A02F46 /* CollectionViewCell.xib */; };
 		D4258B6C26086153006EDA08 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4258B6B26086153006EDA08 /* AppDelegate.swift */; };
 		D4258B6E26086153006EDA08 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4258B6D26086153006EDA08 /* SceneDelegate.swift */; };
 		D4258B7026086153006EDA08 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4258B6F26086153006EDA08 /* ViewController.swift */; };
@@ -36,7 +37,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		BD40D1802609885300A02F46 /* CollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewCell.swift; sourceTree = "<group>"; };
+		BD40D1902609B5A200A02F46 /* CollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewCell.swift; sourceTree = "<group>"; };
+		BD40D1912609B5A200A02F46 /* CollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CollectionViewCell.xib; sourceTree = "<group>"; };
 		D4258B6826086153006EDA08 /* PhotosApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PhotosApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4258B6B26086153006EDA08 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D4258B6D26086153006EDA08 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -104,7 +106,8 @@
 				D4258B6B26086153006EDA08 /* AppDelegate.swift */,
 				D4258B6D26086153006EDA08 /* SceneDelegate.swift */,
 				D4258B6F26086153006EDA08 /* ViewController.swift */,
-				BD40D1802609885300A02F46 /* CollectionViewCell.swift */,
+				BD40D1902609B5A200A02F46 /* CollectionViewCell.swift */,
+				BD40D1912609B5A200A02F46 /* CollectionViewCell.xib */,
 				D4258B7126086153006EDA08 /* Main.storyboard */,
 				D4258B7426086155006EDA08 /* Assets.xcassets */,
 				D4258B7626086155006EDA08 /* LaunchScreen.storyboard */,
@@ -236,6 +239,7 @@
 			files = (
 				D4258B7826086155006EDA08 /* LaunchScreen.storyboard in Resources */,
 				D4258B7526086155006EDA08 /* Assets.xcassets in Resources */,
+				BD40D1932609B5A200A02F46 /* CollectionViewCell.xib in Resources */,
 				D4258B7326086153006EDA08 /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -263,7 +267,7 @@
 			files = (
 				D4258B7026086153006EDA08 /* ViewController.swift in Sources */,
 				D4258B6C26086153006EDA08 /* AppDelegate.swift in Sources */,
-				BD40D1812609885300A02F46 /* CollectionViewCell.swift in Sources */,
+				BD40D1922609B5A200A02F46 /* CollectionViewCell.swift in Sources */,
 				D4258B6E26086153006EDA08 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PhotosApp/PhotosApp.xcodeproj/project.pbxproj
+++ b/PhotosApp/PhotosApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BD40D1812609885300A02F46 /* CollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD40D1802609885300A02F46 /* CollectionViewCell.swift */; };
 		D4258B6C26086153006EDA08 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4258B6B26086153006EDA08 /* AppDelegate.swift */; };
 		D4258B6E26086153006EDA08 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4258B6D26086153006EDA08 /* SceneDelegate.swift */; };
 		D4258B7026086153006EDA08 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4258B6F26086153006EDA08 /* ViewController.swift */; };
@@ -35,6 +36,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		BD40D1802609885300A02F46 /* CollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewCell.swift; sourceTree = "<group>"; };
 		D4258B6826086153006EDA08 /* PhotosApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PhotosApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4258B6B26086153006EDA08 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D4258B6D26086153006EDA08 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -102,6 +104,7 @@
 				D4258B6B26086153006EDA08 /* AppDelegate.swift */,
 				D4258B6D26086153006EDA08 /* SceneDelegate.swift */,
 				D4258B6F26086153006EDA08 /* ViewController.swift */,
+				BD40D1802609885300A02F46 /* CollectionViewCell.swift */,
 				D4258B7126086153006EDA08 /* Main.storyboard */,
 				D4258B7426086155006EDA08 /* Assets.xcassets */,
 				D4258B7626086155006EDA08 /* LaunchScreen.storyboard */,
@@ -260,6 +263,7 @@
 			files = (
 				D4258B7026086153006EDA08 /* ViewController.swift in Sources */,
 				D4258B6C26086153006EDA08 /* AppDelegate.swift in Sources */,
+				BD40D1812609885300A02F46 /* CollectionViewCell.swift in Sources */,
 				D4258B6E26086153006EDA08 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PhotosApp/PhotosApp/Base.lproj/Main.storyboard
+++ b/PhotosApp/PhotosApp/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="idf-Hk-Oyu">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
@@ -9,7 +9,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--Photos-->
         <scene sceneID="tne-QT-ifu">
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="PhotosApp" customModuleProvider="target" sceneMemberID="viewController">
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="utY-cp-fGs">
-                                <rect key="frame" x="20" y="44" width="374" height="818"/>
+                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="aTy-jA-XKy">
@@ -43,11 +43,32 @@
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
+                    <navigationItem key="navigationItem" title="Photos" id="3JA-uy-gih">
+                        <barButtonItem key="rightBarButtonItem" systemItem="done" id="ICQ-Qg-Y8i"/>
+                    </navigationItem>
                     <connections>
                         <outlet property="mainCollectionView" destination="utY-cp-fGs" id="cCJ-FR-rKu"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="923.1884057971015" y="88.392857142857139"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="Hdi-Ms-uvW">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="idf-Hk-Oyu" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="Vai-af-0XW">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="JS2-zr-PJv"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="cvx-DH-yvH" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="13.043478260869566" y="88.392857142857139"/>
         </scene>

--- a/PhotosApp/PhotosApp/Base.lproj/Main.storyboard
+++ b/PhotosApp/PhotosApp/Base.lproj/Main.storyboard
@@ -21,7 +21,7 @@
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="aTy-jA-XKy">
+                                <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="aTy-jA-XKy">
                                     <size key="itemSize" width="128" height="128"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>

--- a/PhotosApp/PhotosApp/CollectionViewCell.swift
+++ b/PhotosApp/PhotosApp/CollectionViewCell.swift
@@ -6,24 +6,19 @@
 //
 
 import UIKit
-import Photos
 
 class CollectionViewCell: UICollectionViewCell {
     
     @IBOutlet weak var cellImageView: UIImageView!
+    static let identifier = "CollectionViewCell"
     
     override func awakeFromNib() {
         super.awakeFromNib()
-        self.cellImageView.contentMode = .scaleAspectFill
+        cellImageView.contentMode = .scaleToFill
     }
     
-}
-
-extension UIColor {
-    static func makeRandomColor() -> UIColor {
-        let randomRed:CGFloat = CGFloat(drand48())
-        let randomGreen:CGFloat = CGFloat(drand48())
-        let randomBlue:CGFloat = CGFloat(drand48())
-        return UIColor(red: randomRed, green: randomGreen, blue: randomBlue, alpha: 1.0)
+    static func nib() -> UINib {
+        return UINib(nibName: identifier, bundle: nil)
     }
+    
 }

--- a/PhotosApp/PhotosApp/CollectionViewCell.swift
+++ b/PhotosApp/PhotosApp/CollectionViewCell.swift
@@ -1,0 +1,33 @@
+//
+//  CollectionViewCell.swift
+//  PhotosApp
+//
+//  Created by sonjuhyeong on 2021/03/23.
+//
+
+import UIKit
+
+class CollectionViewCell: UICollectionViewCell {
+    static let identifier = "rectangleCell"
+   
+    private let randomColor: UIColor = {
+        let randomRed:CGFloat = CGFloat(drand48())
+        let randomGreen:CGFloat = CGFloat(drand48())
+        let randomBlue:CGFloat = CGFloat(drand48())
+        return UIColor(red: randomRed, green: randomGreen, blue: randomBlue, alpha: 1.0)
+    }()
+    
+//    private let pictureView: UIImageView = {
+//        let imageView = UIImageView()
+//        imageView.image = UIImage(systemName: <#T##String#>)
+//        return imageView
+//    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        contentView.backgroundColor = randomColor
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }}

--- a/PhotosApp/PhotosApp/CollectionViewCell.swift
+++ b/PhotosApp/PhotosApp/CollectionViewCell.swift
@@ -6,10 +6,11 @@
 //
 
 import UIKit
+import Photos
 
 class CollectionViewCell: UICollectionViewCell {
-    static let identifier = "rectangleCell"
-   
+    @IBOutlet weak var cellImageView: UIImageView!
+    
     private let randomColor: UIColor = {
         let randomRed:CGFloat = CGFloat(drand48())
         let randomGreen:CGFloat = CGFloat(drand48())
@@ -17,17 +18,14 @@ class CollectionViewCell: UICollectionViewCell {
         return UIColor(red: randomRed, green: randomGreen, blue: randomBlue, alpha: 1.0)
     }()
     
-//    private let pictureView: UIImageView = {
-//        let imageView = UIImageView()
-//        imageView.image = UIImage(systemName: <#T##String#>)
-//        return imageView
-//    }()
-    
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        contentView.backgroundColor = randomColor
+    override func awakeFromNib() {
+        
+        super.awakeFromNib()
+        self.cellImageView.contentMode = .scaleAspectFill
     }
     
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }}
+    func configure(with image: UIImage?) {
+        self.cellImageView.image = image
+    }
+    
+}

--- a/PhotosApp/PhotosApp/CollectionViewCell.swift
+++ b/PhotosApp/PhotosApp/CollectionViewCell.swift
@@ -9,23 +9,21 @@ import UIKit
 import Photos
 
 class CollectionViewCell: UICollectionViewCell {
+    
     @IBOutlet weak var cellImageView: UIImageView!
     
-    private let randomColor: UIColor = {
-        let randomRed:CGFloat = CGFloat(drand48())
-        let randomGreen:CGFloat = CGFloat(drand48())
-        let randomBlue:CGFloat = CGFloat(drand48())
-        return UIColor(red: randomRed, green: randomGreen, blue: randomBlue, alpha: 1.0)
-    }()
-    
     override func awakeFromNib() {
-        
         super.awakeFromNib()
         self.cellImageView.contentMode = .scaleAspectFill
     }
     
-    func configure(with image: UIImage?) {
-        self.cellImageView.image = image
+}
+
+extension UIColor {
+    static func makeRandomColor() -> UIColor {
+        let randomRed:CGFloat = CGFloat(drand48())
+        let randomGreen:CGFloat = CGFloat(drand48())
+        let randomBlue:CGFloat = CGFloat(drand48())
+        return UIColor(red: randomRed, green: randomGreen, blue: randomBlue, alpha: 1.0)
     }
-    
 }

--- a/PhotosApp/PhotosApp/CollectionViewCell.xib
+++ b/PhotosApp/PhotosApp/CollectionViewCell.xib
@@ -16,13 +16,18 @@
                 <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
-                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ONk-Bf-BKD">
-                        <rect key="frame" x="-95" y="-39" width="240" height="128"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ONk-Bf-BKD">
+                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                     </imageView>
                 </subviews>
             </view>
             <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
+            <constraints>
+                <constraint firstItem="ONk-Bf-BKD" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="LAT-08-9q3"/>
+                <constraint firstAttribute="trailing" secondItem="ONk-Bf-BKD" secondAttribute="trailing" id="o81-MZ-IgQ"/>
+                <constraint firstAttribute="bottom" secondItem="ONk-Bf-BKD" secondAttribute="bottom" id="t2M-Wa-kQ5"/>
+                <constraint firstItem="ONk-Bf-BKD" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="w0J-FE-HtF"/>
+            </constraints>
             <connections>
                 <outlet property="cellImageView" destination="ONk-Bf-BKD" id="eRl-iW-Rpw"/>
             </connections>

--- a/PhotosApp/PhotosApp/CollectionViewCell.xib
+++ b/PhotosApp/PhotosApp/CollectionViewCell.xib
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="gTV-IL-0wX" customClass="CollectionViewCell" customModule="PhotosApp" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                <subviews>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ONk-Bf-BKD">
+                        <rect key="frame" x="-95" y="-39" width="240" height="128"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    </imageView>
+                </subviews>
+            </view>
+            <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
+            <connections>
+                <outlet property="cellImageView" destination="ONk-Bf-BKD" id="eRl-iW-Rpw"/>
+            </connections>
+            <point key="canvasLocation" x="-210.1449275362319" y="94.419642857142847"/>
+        </collectionViewCell>
+    </objects>
+</document>

--- a/PhotosApp/PhotosApp/ExtentionUIColor.swift
+++ b/PhotosApp/PhotosApp/ExtentionUIColor.swift
@@ -1,0 +1,17 @@
+//
+//  ExtentionUIColor.swift
+//  PhotosApp
+//
+//  Created by sonjuhyeong on 2021/03/24.
+//
+
+import UIKit
+
+extension UIColor {
+    static func makeRandomColor() -> UIColor {
+        let randomRed:CGFloat = CGFloat(drand48())
+        let randomGreen:CGFloat = CGFloat(drand48())
+        let randomBlue:CGFloat = CGFloat(drand48())
+        return UIColor(red: randomRed, green: randomGreen, blue: randomBlue, alpha: 1.0)
+    }
+}

--- a/PhotosApp/PhotosApp/Info.plist
+++ b/PhotosApp/PhotosApp/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string></string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/PhotosApp/PhotosApp/ViewController.swift
+++ b/PhotosApp/PhotosApp/ViewController.swift
@@ -41,9 +41,12 @@ extension ViewController: UICollectionViewDataSource {
         if let asset = self.allPhotos?[indexPath.item] {
             LocalImageManager.shared.requestImage(with: asset, thumbnailSize: self.thumbnailSize, completion: {image in cell.configure(with: image)})
         }
-        
-        
         return cell
+    }
+    
+    // 편집 가능한지 요청하는 메소드
+    func collectionView(_ collectionView: UICollectionView, canEditItemAt indexPath: IndexPath) -> Bool {
+        return true
     }
 }
 
@@ -78,3 +81,13 @@ class LocalImageManager {
     }
 }
 
+extension ViewController: PHPhotoLibraryChangeObserver {
+    func photoLibraryDidChange(_ changeInstance: PHChange) {
+        if let changed = changeInstance.changeDetails(for: allPhotos!){
+            allPhotos = changed.fetchResultAfterChanges
+        }
+        DispatchQueue.main.sync {
+            self.mainCollectionView.reloadData()
+        }
+    }
+}

--- a/PhotosApp/PhotosApp/ViewController.swift
+++ b/PhotosApp/PhotosApp/ViewController.swift
@@ -9,16 +9,20 @@ import UIKit
 
 class ViewController: UIViewController {
 
+    //MARK: - Properties
     @IBOutlet weak var mainCollectionView: UICollectionView!
     
+    //MARK: - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.mainCollectionView.delegate = self
-        self.mainCollectionView.dataSource = self
+        mainCollectionView.delegate = self
+        mainCollectionView.dataSource = self
+        mainCollectionView.register(CollectionViewCell.self, forCellWithReuseIdentifier: CollectionViewCell.identifier)
     }
 }
 
+//MARK: - UICollectionViewDataSource, UICollectionViewDelegateFlowLayout
 extension ViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
@@ -26,19 +30,9 @@ extension ViewController: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = mainCollectionView.dequeueReusableCell(withReuseIdentifier: "rectangleCell", for: indexPath)
+        let cell = mainCollectionView.dequeueReusableCell(withReuseIdentifier: CollectionViewCell.identifier, for: indexPath)
 
-        cell.backgroundColor = UIColor.random()
         return cell
-    }
-}
-
-extension UIColor {
-    static func random() -> UIColor{
-        return UIColor(red: CGFloat.random(in: 0...1),
-                       green: CGFloat.random(in: 0...1),
-                       blue: CGFloat.random(in: 0...1),
-                       alpha: 1)
     }
 }
 
@@ -48,12 +42,8 @@ extension ViewController: UICollectionViewDelegateFlowLayout {
         return CGSize(width: 80, height: 80)
     }
     
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
-        return 10.0
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-        return 5.0
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+        return UIEdgeInsets(top: 5, left: 10, bottom: 5, right: 10)
     }
 }
 

--- a/PhotosApp/PhotosApp/ViewController.swift
+++ b/PhotosApp/PhotosApp/ViewController.swift
@@ -18,19 +18,18 @@ class ViewController: UIViewController {
     //MARK: - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+        PHPhotoLibrary.shared().register(self)
         mainCollectionView.delegate = self
         mainCollectionView.dataSource = self
-        
-        let nibName = UINib(nibName: "CollectionViewCell", bundle: nil)
-        mainCollectionView.register(nibName, forCellWithReuseIdentifier: "CollectionViewCell")
+        mainCollectionView.register(CollectionViewCell.nib(), forCellWithReuseIdentifier: CollectionViewCell.identifier)
         requestImage()
         self.mainCollectionView.reloadData()
     }
     
+    //MARK: - fetchAssets 메소드
     func requestImage() {
         let fetchOptions = PHFetchOptions()
-        fetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
+        fetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: true)]
         self.allPhotos = PHAsset.fetchAssets(with: fetchOptions)
     }
 }
@@ -43,17 +42,13 @@ extension ViewController: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "CollectionViewCell", for: indexPath) as! CollectionViewCell
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CollectionViewCell.identifier, for: indexPath) as! CollectionViewCell
         
         let asset: PHAsset = allPhotos!.object(at: indexPath.row)
         imageManager.requestImage(for: asset, targetSize: CGSize(width: 100, height: 100), contentMode: .aspectFill, options: nil, resultHandler: {image, _ in cell.cellImageView.image = image})
         return cell
     }
     
-    // 편집 가능한지 요청하는 메소드
-    func collectionView(_ collectionView: UICollectionView, canEditItemAt indexPath: IndexPath) -> Bool {
-        return true
-    }
 }
 
 extension ViewController: UICollectionViewDelegateFlowLayout {
@@ -73,7 +68,7 @@ extension ViewController: PHPhotoLibraryChangeObserver {
         if let changed = changeInstance.changeDetails(for: allPhotos!){
             allPhotos = changed.fetchResultAfterChanges
         }
-        DispatchQueue.main.sync {
+        DispatchQueue.main.async {
             self.mainCollectionView.reloadData()
         }
     }

--- a/README.md
+++ b/README.md
@@ -17,3 +17,23 @@ iOS 연습 - 11팀(Min, Aiden)
 
 ### 완성날짜
 * 2021-03-22
+
+
+## Step2
+
+### 요구사항
+* UINavigationController를 Embed시키고, 타이틀을 'Photos'로 지정한다.
+
+* PHAsset 프레임워크를 사용해서 사진보관함에 있는 사진 이미지를 Cell에 표시한다.
+
+* PHCachingImageManager 클래스를 활용해서 썸네일 이미지를 100 x 100 크기로 생성해서 Cell에 표시한다.
+
+* PHPhotoLibrary 클래스에 사진보관함이 변경되는지 여부를 옵저버로 등록한다.
+
+
+### 실행결과
+
+![Simulator Screen Shot - iPhone 12 - 2021-03-24 at 14 47 47](https://user-images.githubusercontent.com/73586326/112262801-93b2ca00-8cb1-11eb-8aaa-4ee1a92a16d8.png)
+
+### 완성날짜
+* 2021-03-24


### PR DESCRIPTION
- [x] UINavigationController를 Embed시키고, 타이틀을 'Photos'로 지정한다.
- [x] PHAsset 프레임워크를 사용해서 사진보관함에 있는 사진 이미지를 Cell에 표시한다.
- [x] PHCachingImageManager 클래스를 활용해서 썸네일 이미지를 100 x 100 크기로 생성해서 Cell에 표시한다.
- [x] PHPhotoLibrary 클래스에 사진보관함이 변경되는지 여부를 옵저버로 등록한다.

- 학습 키워드: UINavigationController, PHAsset, PHCachingImageManager, PHPhotoLibraryChangeObserver
- 고민과 해결: UICollectionView Cell의 각각 사진 이미지를 불러오는 방법에 대해 어떻게 해야할지 고민을 많이 해보았습니다. 먼저 Custom Cell을 만들기 위하여 CollectionViewCell 클래스를 만들어 주었고 추가적으로 xib를 생성하여 Cell에 대한 이미지를 처리할 수 있게 해주었습니다. PHAsset을 fetch한 결과 값의 배열인 PHFetchResult에 PHAsset 클래스의 fetchAsset 메소드를 통하여 PHAsset의 메타 데이터들을 넣어주었습니다. 그리고 UICollectionViewDataSource를 채택한 ViewController 내부에서 PHAsset 데이터 숫자만큼 Cell의 갯수를 지정해준 후 PHCachingImageManager 클래스의 requestImage를 통하여 각각 Cell과 PHAsset의 메타 데이터들을 매칭시켜주었습니다. 마지막으로 PHPhotoLibraryChangeObserver 프로토콜을 채택하여 사진첩의 사진의 변화를 감지하면 CollectionView를 reload 시키게 해주었습니다.